### PR TITLE
Add 1-click release process

### DIFF
--- a/.github/scripts/bump-changelog.sh
+++ b/.github/scripts/bump-changelog.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Rolls the [Unreleased] section of CHANGELOG.md into a new versioned section
+# and updates the comparison links at the bottom of the file.
+#
+# Usage: bump-changelog.sh vX.Y.Z
+
+set -euo pipefail
+
+if [[ $# -ne 1 || ! "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: $0 vX.Y.Z" >&2
+  exit 1
+fi
+
+VERSION="${1#v}"
+DATE="$(date -u +%Y-%m-%d)"
+CHANGELOG="CHANGELOG.md"
+REPO_URL="https://github.com/dash0hq/otel-cicd-action"
+
+UNRELEASED_CONTENT="$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' "$CHANGELOG")"
+if [[ -z "$(printf '%s' "$UNRELEASED_CONTENT" | grep -v '^[[:space:]]*$' || true)" ]]; then
+  echo "The [Unreleased] section of $CHANGELOG is empty; nothing to release." >&2
+  exit 1
+fi
+
+PREVIOUS="$(grep -E '^\[unreleased\]: ' "$CHANGELOG" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+if [[ -z "$PREVIOUS" ]]; then
+  echo "Could not determine the previous version from the [unreleased] link in $CHANGELOG." >&2
+  exit 1
+fi
+
+awk -v ver="$VERSION" -v date="$DATE" -v prev="$PREVIOUS" -v url="$REPO_URL" '
+  /^## \[Unreleased\]$/ {
+    print
+    print ""
+    print "## [" ver "] - " date
+    next
+  }
+  /^\[unreleased\]: / {
+    print "[unreleased]: " url "/compare/v" ver "...HEAD"
+    print "[" ver "]: " url "/compare/" prev "...v" ver
+    next
+  }
+  { print }
+' "$CHANGELOG" > "$CHANGELOG.tmp"
+mv "$CHANGELOG.tmp" "$CHANGELOG"
+
+echo "Updated $CHANGELOG for v$VERSION (previous release: $PREVIOUS)."

--- a/.github/scripts/extract-release-notes.sh
+++ b/.github/scripts/extract-release-notes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Prints the CHANGELOG.md section for the given version, for use as the
+# GitHub Release body.
+#
+# Usage: extract-release-notes.sh vX.Y.Z
+
+set -euo pipefail
+
+if [[ $# -ne 1 || ! "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: $0 vX.Y.Z" >&2
+  exit 1
+fi
+
+VERSION="${1#v}"
+CHANGELOG="CHANGELOG.md"
+
+NOTES="$(awk -v ver="$VERSION" '
+  $0 ~ ("^## \\[" ver "\\]") { flag=1; next }
+  /^## \[/ { flag=0 }
+  /^\[unreleased\]: / { flag=0 }
+  flag
+' "$CHANGELOG")"
+
+if [[ -z "$(printf '%s' "$NOTES" | grep -v '^[[:space:]]*$' || true)" ]]; then
+  echo "No changelog section found for v$VERSION in $CHANGELOG." >&2
+  exit 1
+fi
+
+printf '%s\n' "$NOTES"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,87 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type (ignored if an explicit version is given)"
+        type: choice
+        options: [patch, minor, major]
+        default: minor
+      version:
+        description: "Explicit version to release (e.g. 4.1.0), overrides the bump type"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    if: github.repository == 'dash0hq/otel-cicd-action'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # An optional fine-grained PAT (contents + pull-requests: write). When
+          # set, the release PR triggers the regular CI checks; PRs created with
+          # the default GITHUB_TOKEN do not (a GitHub Actions limitation).
+          token: ${{ secrets.RELEASE_PAT || github.token }}
+      - name: Determine next version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          EXPLICIT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -n "$EXPLICIT_VERSION" ]]; then
+            VERSION="v${EXPLICIT_VERSION#v}"
+            if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid version: $EXPLICIT_VERSION (expected X.Y.Z)" >&2
+              exit 1
+            fi
+          else
+            LATEST=$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+            echo "Latest release: $LATEST"
+            IFS=. read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
+            case "$BUMP" in
+              major) VERSION="v$((MAJOR + 1)).0.0" ;;
+              minor) VERSION="v${MAJOR}.$((MINOR + 1)).0" ;;
+              patch) VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            esac
+          fi
+          if git rev-parse --verify --quiet "refs/tags/$VERSION" > /dev/null; then
+            echo "Tag $VERSION already exists." >&2
+            exit 1
+          fi
+          echo "Next release: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Update package.json and CHANGELOG.md
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          npm version "${VERSION#v}" --no-git-tag-version
+          ./.github/scripts/bump-changelog.sh "$VERSION"
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          BRANCH="release/$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "chore: prepare release $VERSION"
+          git push --set-upstream origin "$BRANCH"
+          gh pr create \
+            --title "chore: prepare release $VERSION" \
+            --body "$(cat <<EOF
+          Prepares the $VERSION release: bumps the version in \`package.json\` and rolls the
+          \`[Unreleased]\` section of \`CHANGELOG.md\` into the $VERSION section.
+
+          Merging this PR (squash merge, keeping the PR title as the commit title) creates
+          the \`$VERSION\` tag, moves the \`${VERSION%%.*}\` major tag, and publishes the
+          GitHub release automatically. See \`RELEASING.md\` for details.
+          EOF
+          )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # Runs on every push to main, but only acts when the head commit is the
+    # squash-merged "chore: prepare release vX.Y.Z" commit created by the
+    # "Prepare release" workflow.
+    if: "github.repository == 'dash0hq/otel-cicd-action' && startsWith(github.event.head_commit.message, 'chore: prepare release v')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Extract version from commit message
+        id: version
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          if [[ "$COMMIT_MSG" =~ ^chore:\ prepare\ release\ (v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "The head commit does not look like a release commit: $COMMIT_MSG" >&2
+            exit 1
+          fi
+      - name: Create release tag and move major tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          MAJOR="${VERSION%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git tag --force "$MAJOR"
+          git push origin "$VERSION"
+          git push --force origin "$MAJOR"
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ./.github/scripts/extract-release-notes.sh "$VERSION" > release-notes.md
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file release-notes.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,28 @@
+# Releasing
+
+Releases are automated and require a single manual trigger plus a PR review.
+The process is inspired by the one of [open-telemetry/opentelemetry-injector](https://github.com/open-telemetry/opentelemetry-injector).
+
+## How to release
+
+1. Make sure the `[Unreleased]` section of [CHANGELOG.md](CHANGELOG.md) is up to date. The release fails if it is empty.
+2. Trigger the [Prepare release](../../actions/workflows/prepare-release.yml) workflow from the Actions tab.
+   Pick the bump type (`patch`, `minor`, or `major`), or provide an explicit version to override it.
+   The next version is computed from the latest `vX.Y.Z` tag.
+3. The workflow opens a PR titled `chore: prepare release vX.Y.Z` that bumps the version in `package.json`/`package-lock.json` and rolls the `[Unreleased]` changelog section into a dated `vX.Y.Z` section.
+4. Review and **squash-merge** the PR, keeping the PR title as the commit title.
+   The [Release](../../actions/workflows/release.yml) workflow detects the release commit on `main` and automatically:
+   - creates the `vX.Y.Z` tag,
+   - moves the floating major tag (e.g. `v4`) to the release commit,
+   - publishes a GitHub release whose notes are the changelog section for that
+     version.
+
+That's it — nothing else to click.
+
+## Notes
+
+- The release commit is matched by its message (`chore: prepare release vX.Y.Z`), so do not reword the PR title when merging, and do not use a merge commit or rebase merge.
+- PRs created with the default `GITHUB_TOKEN` do not trigger CI checks (a GitHub Actions limitation).
+  To have the regular checks run on the release PR, configure a `RELEASE_PAT` repository secret containing a fine-grained personal access token with `contents: write` and `pull-requests: write` permissions on this repository.
+  Without it, the release PR shows no checks; `main` was already validated by CI on every merged PR, so this is safe but requires an admin merge if branch protection mandates the checks.
+- Major version bumps change the floating tag users reference (`dash0hq/otel-cicd-action@v4` → `@v5`): remember to update the references in [README.md](README.md) in the release PR or a follow-up.


### PR DESCRIPTION
Adds an automated release process inspired by the one of [open-telemetry/opentelemetry-injector](https://github.com/open-telemetry/opentelemetry-injector), adapted to this repo's conventions (Keep-a-Changelog `[Unreleased]` section, `package.json` version, floating major tags like `v4`).

## How it works

1. **Prepare release** (`workflow_dispatch`, the one click): computes the next version from the latest `vX.Y.Z` tag plus a `patch`/`minor`/`major` bump input (or an explicit version), bumps `package.json`/`package-lock.json`, rolls the `[Unreleased]` changelog section into a dated `## [X.Y.Z]` section (updating the compare links), and opens a PR titled `chore: prepare release vX.Y.Z`. It refuses to run if the tag already exists or the `[Unreleased]` section is empty.
2. **Release** (on push to `main`): when the head commit matches the release commit message (i.e. the release PR was squash-merged), it creates the `vX.Y.Z` tag, force-moves the major tag, and publishes a GitHub release whose body is that version's changelog section.

Unlike the injector, no GitHub App token is needed: tagging and release creation happen in the same push-triggered job, so the default `GITHUB_TOKEN` suffices. An optional `RELEASE_PAT` secret can be configured so the bot-created release PR triggers regular CI checks (PRs opened with `GITHUB_TOKEN` don't, per GitHub Actions limitations).

The changelog scripts were tested locally against the real `CHANGELOG.md`: section roll-over, compare-link updates, release-notes extraction for current and historical versions, and the empty-section guard.

See `RELEASING.md` for the full documentation.