### PR TITLE
Use Dash0 endpoints in README examples, drop competitor links from website docs

### DIFF
--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -98,6 +98,18 @@ files:
         type: remove-line
         line: "[license-img]: "
 
+      - description: remove the Axiom sample workflow row (no competitor links on dash0.com)
+        type: remove-line
+        line: "[axiom.yml]"
+
+      - description: remove the New Relic sample workflow row (no competitor links on dash0.com)
+        type: remove-line
+        line: "[newrelic.yml]"
+
+      - description: remove the Honeycomb sample workflow row (no competitor links on dash0.com)
+        type: remove-line
+        line: "[honeycomb.yml]"
+
       - description: rewrite relative GitHub links to absolute
         type: replace-regex
         find: '\[([^\]]+)\]\((?!https?://|/)([^)]+)\)'

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: dash0hq/otel-cicd-action@v4
         with:
-          otlpEndpoint: grpc://api.honeycomb.io:443/
+          otlpEndpoint: grpc://ingress.eu-west-1.aws.dash0.com:4317
           otlpHeaders: ${{ secrets.OTLP_HEADERS }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           runId: ${{ github.event.workflow_run.id }}
@@ -70,7 +70,7 @@ jobs:
       - name: Export workflow
         uses: dash0hq/otel-cicd-action@v4
         with:
-          otlpEndpoint: grpc://api.honeycomb.io:443/
+          otlpEndpoint: grpc://ingress.eu-west-1.aws.dash0.com:4317
           otlpHeaders: ${{ secrets.OTLP_HEADERS }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -134,15 +134,15 @@ man-in-the-middle attacks. Only use it with a trusted internal endpoint.
 
 ### Action Inputs
 
-| name                   | description                                                                                                              | required | default                               | example                                                          |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------- | ---------------------------------------------------------------- |
-| otlpEndpoint           | The destination endpoint to export OpenTelemetry traces to. It supports `https://`, `http://` and `grpc://` endpoints.   | true     |                                       | `https://api.axiom.co/v1/traces`                                 |
-| otlpHeaders            | Headers to add to the OpenTelemetry exporter.                                                                            | true     |                                       | `x-honeycomb-team=YOUR_API_KEY,x-honeycomb-dataset=YOUR_DATASET` |
-| otelServiceName        | OpenTelemetry service name                                                                                               | false    | `<The name of the exported workflow>` | `Build CI`                                                       |
-| githubToken            | The repository token with Workflow permissions. Required for private repos                                               | false    |                                       | `${{ secrets.GITHUB_TOKEN }}`                                    |
-| runId                  | Workflow Run ID to Export                                                                                                | false    | env.GITHUB_RUN_ID                     | `${{ github.event.workflow_run.id }}`                            |
-| extraAttributes        | Extra resource attributes to add to each span                                                                            | false    |                                       | `extra.attribute=1,key2=value2`                                  |
-| otlpInsecureSkipVerify | Disable TLS certificate verification for the OTLP exporter. Only use this with trusted endpoints.                        | false    | `false`                               | `true`                                                           |
+| name                   | description                                                                                                              | required | default                               | example                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------- | ----------------------------------------------------------------- |
+| otlpEndpoint           | The destination endpoint to export OpenTelemetry traces to. It supports `https://`, `http://` and `grpc://` endpoints.   | true     |                                       | `https://ingress.eu-west-1.aws.dash0.com/v1/traces`               |
+| otlpHeaders            | Headers to add to the OpenTelemetry exporter.                                                                            | true     |                                       | `Authorization=Bearer YOUR_AUTH_TOKEN,Dash0-Dataset=YOUR_DATASET` |
+| otelServiceName        | OpenTelemetry service name                                                                                               | false    | `<The name of the exported workflow>` | `Build CI`                                                        |
+| githubToken            | The repository token with Workflow permissions. Required for private repos                                               | false    |                                       | `${{ secrets.GITHUB_TOKEN }}`                                     |
+| runId                  | Workflow Run ID to Export                                                                                                | false    | env.GITHUB_RUN_ID                     | `${{ github.event.workflow_run.id }}`                             |
+| extraAttributes        | Extra resource attributes to add to each span                                                                            | false    |                                       | `extra.attribute=1,key2=value2`                                   |
+| otlpInsecureSkipVerify | Disable TLS certificate verification for the OTLP exporter. Only use this with trusted endpoints.                        | false    | `false`                               | `true`                                                            |
 
 ### Action Outputs
 


### PR DESCRIPTION
Two related cleanups:

1. **README examples now reference Dash0.** The two usage snippets point at `grpc://ingress.eu-west-1.aws.dash0.com:4317` (previously Honeycomb), and the action-inputs table shows `https://ingress.eu-west-1.aws.dash0.com/v1/traces` and `Authorization=Bearer YOUR_AUTH_TOKEN,Dash0-Dataset=YOUR_DATASET` as the `otlpEndpoint`/`otlpHeaders` examples (previously Axiom/Honeycomb). The vendor-specific sample workflows (`axiom.yml`, `newrelic.yml`, `honeycomb.yml`) stay — the action remains vendor-neutral.

2. **Competitor links are stripped from the website docs.** New `remove-line` transformations drop the Axiom, New Relic, and Honeycomb sample-workflow table rows from the page synced to dash0.com/docs. They are `required`, so renaming those rows in the README fails the sync dry-run instead of silently drifting.

The "Synchronize CI/CD Action docs" PR check validates the transformations in dry-run mode.