### PR TITLE
ci: skip the sourcemap when diffing dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
         run: npm run build
       - name: Validate dist
         run: |
-          git diff
+          git status --porcelain
+          # Diff everything except the sourcemap: dist/index.js.map is a 15 MB
+          # single-line file, and streaming its diff to the log takes minutes.
+          git diff -- . ':(exclude)*.map'
           exit $(git status --porcelain | wc -l)
   tests:
     strategy:


### PR DESCRIPTION
dist/index.js.map is a 15 MB single-line file. Streaming its diff to the job log dominated the Validate dist step, pushing the build job to nearly ten minutes on a stale-bundle failure.

This change excludes the distro from the diff and prints `git status` first, so a stale sourcemap is still reported and still counts toward the step's exit code.